### PR TITLE
Assign UUIDs to pools and executors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,16 @@
 PATH
   remote: .
   specs:
-    hystrix-ruby (0.0.1)
+    hystrix-ruby (0.1.0)
       celluloid (>= 0.13.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    celluloid (0.15.2)
-      timers (~> 1.1.0)
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
     diff-lcs (1.2.4)
+    hitimes (1.2.2)
     multi_json (1.8.2)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -26,7 +27,8 @@ GEM
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
     timecop (0.6.3)
-    timers (1.1.0)
+    timers (4.0.1)
+      hitimes
 
 PLATFORMS
   ruby

--- a/hystrix-ruby.gemspec
+++ b/hystrix-ruby.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
 	s.name = %q{hystrix-ruby}
-	s.version = "0.0.1"
+	s.version = "0.1.0"
 	s.authors = ["Keith Thornhill"]
 	s.date = %q{2013-04-08}
 	s.description = %q{Hystrix for Ruby}

--- a/hystrix-ruby.gemspec
+++ b/hystrix-ruby.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
 	s.name = %q{hystrix-ruby}
-	s.version = "0.1.0"
+	s.version = "0.1.2"
 	s.authors = ["Keith Thornhill"]
 	s.date = %q{2013-04-08}
 	s.description = %q{Hystrix for Ruby}

--- a/lib/hystrix/circuit.rb
+++ b/lib/hystrix/circuit.rb
@@ -3,13 +3,14 @@ module Hystrix
 	class Circuit
 		include Celluloid
 
-		attr_accessor :lock, :health, :recent_latency_errors, :last_health_check_time
+		attr_accessor :lock, :health, :recent_latency_errors, :last_health_check_time, :command_pool
 
-		def initialize
+		def initialize(command_pool)
 			self.lock = Mutex.new
 			self.recent_latency_errors = []
 			self.health = 0
 			self.last_health_check_time = nil
+			self.command_pool = command_pool
 		end
 
 		def is_closed?

--- a/lib/hystrix/command.rb
+++ b/lib/hystrix/command.rb
@@ -39,13 +39,8 @@ module Hystrix
 				duration = Time.now - start_time
 
 				begin
-					if main_error.respond_to?(:cause)
-						result = fallback(main_error.cause)
-						Configuration.notify_fallback({command_name: self.class.name, executor_pool_name: executor_pool_name, duration: duration, error: main_error.cause})
-					else
-						result = fallback(main_error)
-						Configuration.notify_fallback({command_name: self.class.name, executor_pool_name: executor_pool_name, duration: duration, error: main_error})
-					end
+					result = fallback(main_error)
+					Configuration.notify_fallback({command_name: self.class.name, executor_pool_name: executor_pool_name, duration: duration, error: main_error})
 				rescue NotImplementedError => fallback_error
 					Configuration.notify_failure({command_name: self.class.name, executor_pool_name: executor_pool_name, duration: duration, error: main_error, fallback_error: fallback_error})
 					raise main_error

--- a/lib/hystrix/command.rb
+++ b/lib/hystrix/command.rb
@@ -34,20 +34,20 @@ module Hystrix
 				result = executor.run(self)
 				duration = Time.now - start_time
 
-				Configuration.notify_success(executor_pool_name, duration)
+				Configuration.notify_success({command_name: self.class.name, executor_pool_name: executor_pool_name, duration: duration})
 			rescue Exception => main_error
 				duration = Time.now - start_time
 
 				begin
 					if main_error.respond_to?(:cause)
 						result = fallback(main_error.cause)
-						Configuration.notify_fallback(executor_pool_name, duration, main_error.cause)
+						Configuration.notify_fallback({command_name: self.class.name, executor_pool_name: executor_pool_name, duration: duration, error: main_error.cause})
 					else
 						result = fallback(main_error)
-						Configuration.notify_fallback(executor_pool_name, duration, main_error)
+						Configuration.notify_fallback({command_name: self.class.name, executor_pool_name: executor_pool_name, duration: duration, error: main_error})
 					end
 				rescue NotImplementedError => fallback_error
-					Configuration.notify_failure(executor_pool_name, duration, main_error)
+					Configuration.notify_failure({command_name: self.class.name, executor_pool_name: executor_pool_name, duration: duration, error: main_error, fallback_error: fallback_error})
 					raise main_error
 				end
 			ensure

--- a/lib/hystrix/configuration.rb
+++ b/lib/hystrix/configuration.rb
@@ -3,27 +3,27 @@ module Hystrix
 		def self.on_success(&block)
 			@on_success = block
 		end
-		def self.notify_success(command_name, duration)
+		def self.notify_success(params)
 			if @on_success
-				@on_success.call(command_name, duration)
+				@on_success.call(params)
 			end
 		end
 
 		def self.on_fallback(&block)
 			@on_fallback = block
 		end
-		def self.notify_fallback(command_name, duration, error)
+		def self.notify_fallback(params)
 			if @on_fallback
-				@on_fallback.call(command_name, duration, error)
+				@on_fallback.call(params)
 			end
 		end
 
 		def self.on_failure(&block)
 			@on_failure = block
 		end
-		def self.notify_failure(command_name, duration, error)
+		def self.notify_failure(params)
 			if @on_failure
-				@on_failure.call(command_name, duration, error)
+				@on_failure.call(params)
 			end
 		end
 

--- a/lib/hystrix/executor_pool.rb
+++ b/lib/hystrix/executor_pool.rb
@@ -44,7 +44,7 @@ module Hystrix
 			self.executors = {}
 			self.locked_executors = {}
 			self.lock = Mutex.new
-			self.circuit_supervisor = Circuit.supervise
+			self.circuit_supervisor = Circuit.supervise(self.name)
 			size.times do
 				e = CommandExecutor.new(self)
 				self.executors[e.uuid] = e

--- a/spec/lib/hystrix/circuit_spec.rb
+++ b/spec/lib/hystrix/circuit_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe Hystrix::Circuit do
 	context 'health threshold, ' do
 		it 'is healthy if no commands have reported latency errors' do
-			circuit = Hystrix::Circuit.new
+			circuit = Hystrix::Circuit.new("test")
 			circuit.is_healthy?.should == true
 		end
 
 		it 'becomes unhealthy if X commands are slow within the last Y seconds.' do
-			circuit = Hystrix::Circuit.new
+			circuit = Hystrix::Circuit.new("test")
 			5.times do
 				circuit.add_latency_error(rand(10))
 			end
@@ -16,13 +16,13 @@ describe Hystrix::Circuit do
 		end
 
 		it 'opens the circuit when unhealthy' do
-			circuit = Hystrix::Circuit.new
+			circuit = Hystrix::Circuit.new("test")
 			circuit.wrapped_object.stub(:is_healthy?).and_return(false)
 			circuit.is_closed?.should == false
 		end
 
 		it 'prunes old latency errors over time' do
-			circuit = Hystrix::Circuit.new
+			circuit = Hystrix::Circuit.new("test")
 			now = Time.now
 			13.times do |i|
 				Timecop.freeze(now - i) do
@@ -37,7 +37,7 @@ describe Hystrix::Circuit do
 		end
 
 		it 'doesnt recalculate health every closed check' do
-			circuit = Hystrix::Circuit.new
+			circuit = Hystrix::Circuit.new("test")
 			circuit.wrapped_object.should_receive(:calculate_health).once.and_call_original
 			now = Time.now
 			
@@ -49,7 +49,7 @@ describe Hystrix::Circuit do
 		end
 
 		it 'only recalculates health every X seconds' do
-			circuit = Hystrix::Circuit.new
+			circuit = Hystrix::Circuit.new("test")
 			circuit.wrapped_object.should_receive(:calculate_health).twice.and_call_original
 			now = Time.now
 			
@@ -61,7 +61,7 @@ describe Hystrix::Circuit do
 		end
 
 		it 'allows the health to return back to 0' do
-			circuit = Hystrix::Circuit.new
+			circuit = Hystrix::Circuit.new("test")
 			now = Time.now
 			Timecop.freeze(now - 11) do
 				circuit.add_latency_error(rand(10))

--- a/spec/lib/hystrix/command_spec.rb
+++ b/spec/lib/hystrix/command_spec.rb
@@ -15,7 +15,7 @@ describe Hystrix::Command do
 			sleep wait
 
 			if fail
-				abort 'error'
+				raise 'error'
 			else
 				return self.string
 			end

--- a/spec/lib/hystrix/command_spec.rb
+++ b/spec/lib/hystrix/command_spec.rb
@@ -72,9 +72,9 @@ describe Hystrix::Command do
 			test_duration = nil
 
 			Hystrix.configure do
-				on_success do |command_name, duration|
-					test_name = command_name
-					test_duration = duration
+				on_success do |params|
+					test_name = params[:command_name]
+					test_duration = params[:duration]
 				end
 			end
 
@@ -90,10 +90,10 @@ describe Hystrix::Command do
 			test_error = nil
 
 			Hystrix.configure do
-				on_fallback do |command_name, duration, error|
-					test_name = command_name
-					test_duration = duration
-					test_error = error
+				on_fallback do |params|
+					test_name = params[:command_name]
+					test_duration = params[:duration]
+					test_error = params[:error]
 				end
 			end
 
@@ -116,10 +116,10 @@ describe Hystrix::Command do
 			end
 
 			Hystrix.configure do
-				on_failure do |command_name, duration, error|
-					test_name = command_name
-					test_duration = duration
-					test_error = error
+				on_failure do |params|
+					test_name = params[:command_name]
+					test_duration = params[:duration]
+					test_error = params[:error]
 				end
 			end
 
@@ -154,7 +154,7 @@ describe Hystrix::Command do
 
 		it 'sends exception to fallback method on error' do
 			c = CommandHelloWorld.new('keith', 0, true)
-			c.wrapped_object.should_receive(:fallback).with do |error|
+			c.wrapped_object.should_receive(:fallback) do |error|
 				error.message.should == 'error'
 			end
 			c.execute

--- a/spec/lib/hystrix/configuration_spec.rb
+++ b/spec/lib/hystrix/configuration_spec.rb
@@ -7,13 +7,13 @@ describe Hystrix::Configuration do
 
 	it 'defines callbacks via dsl' do
 		Hystrix.configure do
-			on_success do |command_name, duration|
+			on_success do |params|
 				raise 'callback'
 			end
 		end
 
 		expect {
-			Hystrix::Configuration.notify_success('test', 30)
+			Hystrix::Configuration.notify_success({})
 		}.to raise_error('callback')
 	end
 end

--- a/spec/lib/hystrix/executor_pool_spec.rb
+++ b/spec/lib/hystrix/executor_pool_spec.rb
@@ -1,7 +1,11 @@
 require 'spec_helper'
 
 describe Hystrix::CommandExecutor do
-	let(:executor) { Hystrix::CommandExecutor.new }
+	let(:executor) { Hystrix::CommandExecutor.new(Hystrix::CommandExecutorPool.new('test',0)) }
+
+	it 'has a uuid' do
+		executor.uuid.length.should == 36
+	end
 
 	it 'can be locked' do
 		executor.locked?.should == false
@@ -23,6 +27,13 @@ end
 describe Hystrix::CommandExecutorPool do
 	it 'creates pool objects when constructed' do
 		Hystrix::CommandExecutorPool.new('test', 10).executors.size.should == 10
+	end
+
+	context '.uuid' do
+		it 'generates a UUID on creation' do
+			pool = Hystrix::CommandExecutorPool.new('test', 1)
+			pool.uuid.length.should == 36
+		end
 	end
 
 	context '.take' do

--- a/spec/lib/hystrix/inline_spec.rb
+++ b/spec/lib/hystrix/inline_spec.rb
@@ -35,8 +35,8 @@ describe Hystrix::InlineDSL do
 		mock.should_receive(:check).with('sup')
 
 		Hystrix.configure do
-			on_success do |command_name, duration|
-				mock.check(command_name)
+			on_success do |params|
+				mock.check(params[:executor_pool_name])
 			end
 		end
 


### PR DESCRIPTION
Rework executor pool logic for better support of large pools
Pass expanded parameter hashes into callbacks
